### PR TITLE
Introduce code formatting with PHP-CS-Fixer

### DIFF
--- a/administration/format-code.sh
+++ b/administration/format-code.sh
@@ -1,0 +1,1 @@
+(cd $(dirname $(readlink -f ${0}))/../docker-symfony/ && docker-compose exec php php vendor/bin/php-cs-fixer fix .)

--- a/application/.gitignore
+++ b/application/.gitignore
@@ -24,3 +24,8 @@
 ###> phpunit/phpunit ###
 /phpunit.xml
 ###< phpunit/phpunit ###
+
+###> friendsofphp/php-cs-fixer ###
+/.php_cs
+/.php_cs.cache
+###< friendsofphp/php-cs-fixer ###

--- a/application/.php_cs.dist
+++ b/application/.php_cs.dist
@@ -1,0 +1,8 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+;

--- a/application/composer.json
+++ b/application/composer.json
@@ -26,6 +26,7 @@
         "symfony/yaml": "*"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.13",
         "phpunit/phpunit": "^7",
         "symfony/browser-kit": "*",
         "symfony/css-selector": "*",

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "46e513d742140ba387e272208c8a9dc9",
+    "content-hash": "84feb7a6f450a0cebf04372288e07623",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -4968,6 +4968,112 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/semver",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5 || ^5.0.5",
+                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "time": "2016-08-30T16:08:34+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2018-08-31T19:07:57+00:00"
+        },
+        {
             "name": "easycorp/easy-log-handler",
             "version": "v1.0.7",
             "source": {
@@ -5016,6 +5122,102 @@
                 "productivity"
             ],
             "time": "2018-07-27T15:41:37+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "7136aa4e0c5f912e8af82383775460d906168a10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7136aa4e0c5f912e8af82383775460d906168a10",
+                "reference": "7136aa4e0c5f912e8af82383775460d906168a10",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^1.4",
+                "composer/xdebug-handler": "^1.2",
+                "doctrine/annotations": "^1.2",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || >=7.0 <7.3",
+                "php-cs-fixer/diff": "^1.3",
+                "symfony/console": "^3.2 || ^4.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0",
+                "symfony/filesystem": "^3.0 || ^4.0",
+                "symfony/finder": "^3.0 || ^4.0",
+                "symfony/options-resolver": "^3.0 || ^4.0",
+                "symfony/polyfill-php70": "^1.0",
+                "symfony/polyfill-php72": "^1.4",
+                "symfony/process": "^3.0 || ^4.0",
+                "symfony/stopwatch": "^3.0 || ^4.0"
+            },
+            "conflict": {
+                "hhvm": "*"
+            },
+            "require-dev": {
+                "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
+                "justinrainbow/json-schema": "^5.0",
+                "keradus/cli-executor": "^1.1",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.1",
+                "php-cs-fixer/accessible-object": "^1.0",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.0.1",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.0.1",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1",
+                "phpunitgoodpractices/traits": "^1.5.1",
+                "symfony/phpunit-bridge": "^4.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
+                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "classmap": [
+                    "tests/Test/AbstractFixerTestCase.php",
+                    "tests/Test/AbstractIntegrationCaseFactory.php",
+                    "tests/Test/AbstractIntegrationTestCase.php",
+                    "tests/Test/Assert/AssertTokensTrait.php",
+                    "tests/Test/IntegrationCase.php",
+                    "tests/Test/IntegrationCaseFactory.php",
+                    "tests/Test/IntegrationCaseFactoryInterface.php",
+                    "tests/Test/InternalIntegrationCaseFactory.php",
+                    "tests/TestCase.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2018-08-23T13:15:44+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -5217,6 +5419,57 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpspec/prophecy",

--- a/application/src/Controller/ActivationInterface.php
+++ b/application/src/Controller/ActivationInterface.php
@@ -1,17 +1,15 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface ActivationInterface
 {
-    public function deactivate():Response;
-    
-    public function activate():Response;
-}
+    public function deactivate(): Response;
 
+    public function activate(): Response;
+}

--- a/application/src/Controller/CreationInterface.php
+++ b/application/src/Controller/CreationInterface.php
@@ -1,17 +1,15 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface CreationInterface
 {
-    public function create():Response;
-    
-    public function delete():Response;
-}
+    public function create(): Response;
 
+    public function delete(): Response;
+}

--- a/application/src/Controller/DefaultController.php
+++ b/application/src/Controller/DefaultController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -6,9 +7,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class DefaultController extends AbstractController implements DefaultControllerInterface
 {
@@ -17,15 +16,14 @@ class DefaultController extends AbstractController implements DefaultControllerI
      */
     public function imprint(): Response
     {
-        return $this->render("standard/imprint.html.twig");
+        return $this->render('standard/imprint.html.twig');
     }
-    
+
     /**
      * @Route("/", name="homepage")
      */
     public function homepage(): Response
     {
-        return $this->render("standard/homepage.html.twig");
+        return $this->render('standard/homepage.html.twig');
     }
 }
-

--- a/application/src/Controller/DefaultControllerInterface.php
+++ b/application/src/Controller/DefaultControllerInterface.php
@@ -1,17 +1,15 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface DefaultControllerInterface
 {
-    public function homepage():Response;
-    
-    public function imprint():Response;
-}
+    public function homepage(): Response;
 
+    public function imprint(): Response;
+}

--- a/application/src/Controller/ModificationInterface.php
+++ b/application/src/Controller/ModificationInterface.php
@@ -1,15 +1,13 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface ModificationInterface
 {
-    public function modify(int $id):Response;
+    public function modify(int $id): Response;
 }
-

--- a/application/src/Controller/RegistrationController.php
+++ b/application/src/Controller/RegistrationController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use App\Form\UserType;
@@ -7,25 +8,20 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\Form\FormInterface;
 
 class RegistrationController extends AbstractController
 {
-
     /**
-     *
      * @var User
      */
     private $user;
 
     /**
-     *
      * @Route("/register", name="user_register")
      */
-    public function register(Request $request, UserPasswordEncoderInterface $passwordEncoder,TranslatorInterface $translator): Response
+    public function register(Request $request, UserPasswordEncoderInterface $passwordEncoder, TranslatorInterface $translator): Response
     {
         $this->user = new User();
         $form = $this->createForm(UserType::class, $this->user);
@@ -33,11 +29,13 @@ class RegistrationController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $this->encodePassword($passwordEncoder);
             $this->saveUser($translator);
+
             return $this->redirectToRoute('login');
         }
-        return $this->render("user/register.html.twig", array(
-            'form' => $form->createView()
-        ));
+
+        return $this->render('user/register.html.twig', [
+            'form' => $form->createView(),
+        ]);
     }
 
     public function encodePassword(UserPasswordEncoderInterface $passwordEncoder): void
@@ -52,10 +50,9 @@ class RegistrationController extends AbstractController
         $entityManager->persist($this->user);
         try {
             $entityManager->flush();
-            $this->addFlash('success', $translator->trans('User "%username%" created!',['%username%'=>$this->user->getUsername()]));
+            $this->addFlash('success', $translator->trans('User "%username%" created!', ['%username%' => $this->user->getUsername()]));
         } catch (\Exception $exception) {
-            $this->addFlash('danger', $translator->trans('User "%username%" could not be created!',['%username%'=>$this->user->getUsername()]));
+            $this->addFlash('danger', $translator->trans('User "%username%" could not be created!', ['%username%' => $this->user->getUsername()]));
         }
     }
 }
-

--- a/application/src/Controller/SecurityController.php
+++ b/application/src/Controller/SecurityController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -8,30 +9,27 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class SecurityController extends AbstractController
 {
     /**
-     *
      * @Route("/login", name="login")
      */
-    public function login(AuthenticationUtils $authenticationUtils,TranslatorInterface $translator): Response
+    public function login(AuthenticationUtils $authenticationUtils, TranslatorInterface $translator): Response
     {
         $error = $authenticationUtils->getLastAuthenticationError();
         if ($error) {
-            $this->addFlash('danger', $translator->trans($error->getMessageKey(),$error->getMessageData(),'security'));
-        }else{
+            $this->addFlash('danger', $translator->trans($error->getMessageKey(), $error->getMessageData(), 'security'));
+        } else {
             $lastUsername = $authenticationUtils->getLastUsername();
-            if($lastUsername){
-                $this->addFlash('success', $translator->trans('User %user% loged in.',['%user%'=>$lastUsername]));
+            if ($lastUsername) {
+                $this->addFlash('success', $translator->trans('User %user% loged in.', ['%user%' => $lastUsername]));
             }
         }
-        return $this->render("user/login.html.twig",[
-            'last_username'=>$authenticationUtils->getLastUsername(),
+
+        return $this->render('user/login.html.twig', [
+            'last_username' => $authenticationUtils->getLastUsername(),
         ]);
     }
 }
-

--- a/application/src/Controller/SourceController.php
+++ b/application/src/Controller/SourceController.php
@@ -1,32 +1,35 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class SourceController implements SourceControllerInterface
 {
     public function modify(int $id): Response
-    {}
+    {
+    }
 
     public function show(int $id): Response
-    {}
+    {
+    }
 
     public function activate(): Response
-    {}
+    {
+    }
 
     public function create(): Response
-    {}
+    {
+    }
 
     public function delete(): Response
-    {}
+    {
+    }
 
     public function deactivate(): Response
-    {}
-
+    {
+    }
 }
-

--- a/application/src/Controller/SourceControllerInterface.php
+++ b/application/src/Controller/SourceControllerInterface.php
@@ -1,15 +1,13 @@
 <?php
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface SourceControllerInterface extends CreationInterface, ActivationInterface, ModificationInterface
 {
-    public function show(int $id):Response;
+    public function show(int $id): Response;
 }
-

--- a/application/src/Entity/AbstractSource.php
+++ b/application/src/Entity/AbstractSource.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Entity;
 
 use App\Entity\Attribut\IdAttribut;
@@ -6,22 +7,20 @@ use App\Entity\Attribut\NodeAttribut;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * 
  * @author kevinfrantz
+ *
  * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html
  * @ORM\Entity
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
- * @ORM\DiscriminatorMap({"user" = "User"})       
+ * @ORM\DiscriminatorMap({"user" = "User"})
  */
 abstract class AbstractSource implements SourceInterface
-{  
+{
     use IdAttribut,NodeAttribut;
-    
+
     /**
-     * 
      * @var ConfigurationInterface
      */
     protected $configuration;
-    
 }

--- a/application/src/Entity/Attribut/ChildsAttribut.php
+++ b/application/src/Entity/Attribut/ChildsAttribut.php
@@ -1,36 +1,35 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use App\Entity\NodeInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-trait ChildsAttribut {
-    
+trait ChildsAttribut
+{
     /**
-     * Many Nodes have many childs
+     * Many Nodes have many childs.
+     *
      * @ORM\ManyToMany(targetEntity="Node")
      * @ORM\JoinTable(name="nodes_childs",
      *      joinColumns={@ORM\JoinColumn(name="node_id", referencedColumnName="id")},
      *      inverseJoinColumns={@ORM\JoinColumn(name="node_id", referencedColumnName="id")}
      *      )
+     *
      * @var ArrayCollection|NodeInterface[]
      */
     protected $childs;
-    
+
     public function getChilds(): ArrayCollection
     {
         return $this->getChilds();
     }
-    
+
     public function setChilds(ArrayCollection $childs): void
     {
         $this->childs = $childs;
     }
-    
 }
-

--- a/application/src/Entity/Attribut/ChildsAttributeInterface.php
+++ b/application/src/Entity/Attribut/ChildsAttributeInterface.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace App\Entity\Attribut;
+
 use Doctrine\Common\Collections\ArrayCollection;
+
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface ChildsAttributeInterface
 {
-    public function setChilds(ArrayCollection $childs):void;
-    
-    public function getChilds():ArrayCollection;
-}
+    public function setChilds(ArrayCollection $childs): void;
 
+    public function getChilds(): ArrayCollection;
+}

--- a/application/src/Entity/Attribut/IdAttribut.php
+++ b/application/src/Entity/Attribut/IdAttribut.php
@@ -1,27 +1,26 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-trait IdAttribut {
+trait IdAttribut
+{
     /**
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")(strategy="AUTO")
      */
     protected $id;
-    
+
     public function setId(int $id): void
     {
         $this->id = $id;
     }
-    
+
     public function getId(): int
     {
         return $this->id;
     }
 }
-

--- a/application/src/Entity/Attribut/IdAttributInterface.php
+++ b/application/src/Entity/Attribut/IdAttributInterface.php
@@ -1,15 +1,13 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface IdAttributInterface
 {
     public function setId(int $id): void;
-    
+
     public function getId(): int;
 }
-

--- a/application/src/Entity/Attribut/NodeAttribut.php
+++ b/application/src/Entity/Attribut/NodeAttribut.php
@@ -1,30 +1,28 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 use App\Entity\NodeInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-trait NodeAttribut{
+trait NodeAttribut
+{
     /**
      * @var NodeInterface
      * @ORM\OneToOne(targetEntity="Node")
      * @ORM\JoinColumn(name="node_id", referencedColumnName="id")
      */
     protected $node;
-    
+
     public function setNode(NodeInterface $node): void
     {
         $this->node = $node;
     }
-    
+
     public function getNode(): NodeInterface
     {
         return $this->node;
     }
-    
 }
-

--- a/application/src/Entity/Attribut/NodeAttributInterface.php
+++ b/application/src/Entity/Attribut/NodeAttributInterface.php
@@ -1,17 +1,15 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 use App\Entity\NodeInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface NodeAttributInterface
 {
-    public function setNode(NodeInterface $node):void;
-    
-    public function getNode():NodeInterface;
-}
+    public function setNode(NodeInterface $node): void;
 
+    public function getNode(): NodeInterface;
+}

--- a/application/src/Entity/Attribut/ParentAttribut.php
+++ b/application/src/Entity/Attribut/ParentAttribut.php
@@ -1,24 +1,24 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use App\Entity\NodeInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-trait ParentAttribut {
-
+trait ParentAttribut
+{
     /**
-     * Many Nodes have many parents
+     * Many Nodes have many parents.
      *
      * @ORM\ManyToMany(targetEntity="Node")
      * @ORM\JoinTable(name="nodes_parents",
      *      joinColumns={@ORM\JoinColumn(name="node_id", referencedColumnName="id")},
      *      inverseJoinColumns={@ORM\JoinColumn(name="node_id", referencedColumnName="id")}
      *      )
+     *
      * @var ArrayCollection|NodeInterface[]
      */
     protected $parents;
@@ -33,4 +33,3 @@ trait ParentAttribut {
         $this->parents = $parents;
     }
 }
-

--- a/application/src/Entity/Attribut/ParentsAttributInterface.php
+++ b/application/src/Entity/Attribut/ParentsAttributInterface.php
@@ -1,17 +1,15 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface ParentsAttributInterface
 {
-    public function setParents(ArrayCollection $parents):void;
-    
-    public function getParents():ArrayCollection;
-}
+    public function setParents(ArrayCollection $parents): void;
 
+    public function getParents(): ArrayCollection;
+}

--- a/application/src/Entity/Attribut/PasswordAttribut.php
+++ b/application/src/Entity/Attribut/PasswordAttribut.php
@@ -1,24 +1,24 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-trait PasswordAttribut {
+trait PasswordAttribut
+{
     /**
      * @ORM\Column(type="string", length=64)
      */
     protected $password;
-    
-    public function getPassword():?string
+
+    public function getPassword(): ?string
     {
         return $this->password;
     }
-    
-    public function setPassword(string $password):void{
+
+    public function setPassword(string $password): void
+    {
         $this->password = $password;
     }
 }
-

--- a/application/src/Entity/Attribut/PlainPasswordAttribute.php
+++ b/application/src/Entity/Attribut/PlainPasswordAttribute.php
@@ -1,18 +1,18 @@
 <?php
+
 namespace App\Entity\Attribut;
+
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-trait PlainPasswordAttribute {
-
+trait PlainPasswordAttribute
+{
     /**
-     * 
      * @Assert\NotBlank()
      * @Assert\Length(max=4096)
+     *
      * @var string
      */
     private $plainPassword;
@@ -27,4 +27,3 @@ trait PlainPasswordAttribute {
         $this->plainPassword = $password;
     }
 }
-

--- a/application/src/Entity/Attribut/SourceAttribut.php
+++ b/application/src/Entity/Attribut/SourceAttribut.php
@@ -1,27 +1,29 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 use App\Entity\SourceInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-trait SourceAttribut {
+trait SourceAttribut
+{
     /**
      * @ORM\OneToOne(targetEntity="AbstractSource")
      * @ORM\JoinColumn(name="source_id", referencedColumnName="id")
+     *
      * @var SourceInterface
      */
     protected $source;
-    
-    public function getSource():SourceInterface{
+
+    public function getSource(): SourceInterface
+    {
         return $this->source;
     }
-    
-    public function setSource(SourceInterface $source):void{
+
+    public function setSource(SourceInterface $source): void
+    {
         $this->source = $source;
     }
 }
-

--- a/application/src/Entity/Attribut/SourceAttributInterface.php
+++ b/application/src/Entity/Attribut/SourceAttributInterface.php
@@ -1,17 +1,15 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 use App\Entity\SourceInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface SourceAttributInterface
 {
-    public function getSource():SourceInterface;
-    
-    public function setSource(SourceInterface $source):void;
-}
+    public function getSource(): SourceInterface;
 
+    public function setSource(SourceInterface $source): void;
+}

--- a/application/src/Entity/Attribut/UsernameAttribut.php
+++ b/application/src/Entity/Attribut/UsernameAttribut.php
@@ -1,25 +1,26 @@
 <?php
+
 namespace App\Entity\Attribut;
 
 /**
- * This trait doesn't need an own interface because it's covered by symfony
+ * This trait doesn't need an own interface because it's covered by symfony.
+ *
  * @author kevinfrantz
- *        
  */
-trait UsernameAttribut{
-    
+trait UsernameAttribut
+{
     /**
      * @ORM\Column(type="string", length=25, unique=true)
      */
     protected $username;
-    
-    public function getUsername():?string
+
+    public function getUsername(): ?string
     {
         return $this->username;
     }
-    
-    public function setUsername(string $username):void{
+
+    public function setUsername(string $username): void
+    {
         $this->username = \trim($username);
     }
 }
-

--- a/application/src/Entity/Configuration.php
+++ b/application/src/Entity/Configuration.php
@@ -1,48 +1,48 @@
 <?php
+
 namespace App\Entity;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class Configuration implements ConfigurationInterface
 {
     /**
-     * 
      * @var PropertyInterface
      */
     protected $read;
-    
+
     /**
-     * 
      * @var PropertyInterface
      */
     protected $write;
-    
+
     /**
-     * 
      * @var PropertyInterface
      */
     protected $administrate;
-    
+
     public function setAdministrate(Property $administrate): void
-    {}
+    {
+    }
 
     public function getAdministrate(): Property
-    {}
+    {
+    }
 
     public function setWrite(Property $write): void
-    {}
+    {
+    }
 
     public function getWrite(): Property
-    {}
+    {
+    }
 
     public function setRead(Property $read): void
-    {}
+    {
+    }
 
     public function getRead(): Property
-    {}
-
+    {
+    }
 }
-

--- a/application/src/Entity/ConfigurationInterface.php
+++ b/application/src/Entity/ConfigurationInterface.php
@@ -1,24 +1,23 @@
 <?php
+
 namespace App\Entity;
 
 /**
  * This class is not a source!
+ *
  * @author kevinfrantz
- *        
  */
 interface ConfigurationInterface
 {
-    public function setRead(Property $read):void;
-    
-    public function getRead():Property;
-    
-    public function setWrite(Property $write):void;
-    
-    public function getWrite():Property;
-    
-    public function setAdministrate(Property $administrate):void;
-    
-    public function getAdministrate():Property;
-    
-}
+    public function setRead(Property $read): void;
 
+    public function getRead(): Property;
+
+    public function setWrite(Property $write): void;
+
+    public function getWrite(): Property;
+
+    public function setAdministrate(Property $administrate): void;
+
+    public function getAdministrate(): Property;
+}

--- a/application/src/Entity/Node.php
+++ b/application/src/Entity/Node.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -8,7 +9,6 @@ use App\Entity\Attribut\ParentAttribut;
 use App\Entity\Attribut\ChildsAttribut;
 
 /**
- *
  * @author kevinfrantz
  * @ORM\Table(name="node")
  * @ORM\Entity(repositoryClass="App\Repository\NodeRepository")
@@ -16,8 +16,7 @@ use App\Entity\Attribut\ChildsAttribut;
 class Node implements NodeInterface
 {
     use IdAttribut,
-    SourceAttribut, 
-    ParentAttribut, 
+    SourceAttribut,
+    ParentAttribut,
     ChildsAttribut;
 }
-

--- a/application/src/Entity/NodeInterface.php
+++ b/application/src/Entity/NodeInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Entity;
 
 use App\Entity\Attribut\SourceAttributInterface;
@@ -7,10 +8,8 @@ use App\Entity\Attribut\ParentsAttributInterface;
 use App\Entity\Attribut\ChildsAttributeInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
-interface NodeInterface extends SourceAttributInterface, IdAttributInterface,ParentsAttributInterface,ChildsAttributeInterface
-{}
-
+interface NodeInterface extends SourceAttributInterface, IdAttributInterface, ParentsAttributInterface, ChildsAttributeInterface
+{
+}

--- a/application/src/Entity/Property.php
+++ b/application/src/Entity/Property.php
@@ -1,32 +1,29 @@
 <?php
+
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class Property implements PropertyInterface
 {
     /**
-     * 
      * @var ArrayCollection|NodeInterface[]
      */
     protected $whitelist;
-    
+
     /**
-     * 
      * @var ArrayCollection|NodeInterface[]
      */
     protected $blacklist;
-    
+
     public function getLegitimated(): ArrayCollection
-    {}
+    {
+    }
 
     public function isLegitimated(SourceInterface $source): bool
-    {}
-
+    {
+    }
 }
-

--- a/application/src/Entity/PropertyInterface.php
+++ b/application/src/Entity/PropertyInterface.php
@@ -1,17 +1,15 @@
 <?php
+
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface PropertyInterface
 {
-    public function isLegitimated(SourceInterface $source):bool;
-    
-    public function getLegitimated():ArrayCollection;
-}
+    public function isLegitimated(SourceInterface $source): bool;
 
+    public function getLegitimated(): ArrayCollection;
+}

--- a/application/src/Entity/SourceInterface.php
+++ b/application/src/Entity/SourceInterface.php
@@ -1,15 +1,13 @@
 <?php
+
 namespace App\Entity;
 
 use App\Entity\Attribut\NodeAttributInterface;
 use App\Entity\Attribut\IdAttributInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface SourceInterface extends IdAttributInterface, NodeAttributInterface
 {
 }
-

--- a/application/src/Entity/User.php
+++ b/application/src/Entity/User.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -7,7 +8,6 @@ use App\Entity\Attribut\PasswordAttribut;
 use App\Entity\Attribut\PlainPasswordAttribute;
 
 /**
- *
  * @author kevinfrantz
  * @ORM\Table(name="source_user")
  * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
@@ -15,7 +15,7 @@ use App\Entity\Attribut\PlainPasswordAttribute;
 class User extends AbstractSource implements UserInterface
 {
     use UsernameAttribut,PasswordAttribut,PlainPasswordAttribute;
- 
+
     /**
      * @ORM\Column(name="is_active", type="boolean")
      */
@@ -33,7 +33,7 @@ class User extends AbstractSource implements UserInterface
 
     public function getRoles()
     {
-        return array('ROLE_USER');
+        return ['ROLE_USER'];
     }
 
     public function eraseCredentials()
@@ -43,20 +43,19 @@ class User extends AbstractSource implements UserInterface
     /** @see \Serializable::serialize() */
     public function serialize()
     {
-        return serialize(array(
+        return serialize([
             $this->id,
             $this->username,
             $this->password,
-        ));
+        ]);
     }
 
     /** @see \Serializable::unserialize() */
     public function unserialize($serialized)
     {
-        list (
+        list(
             $this->id,
             $this->username,
-            $this->password,
-        ) = unserialize($serialized, array('allowed_classes' => false));
+            $this->password) = unserialize($serialized, ['allowed_classes' => false]);
     }
 }

--- a/application/src/Entity/UserInterface.php
+++ b/application/src/Entity/UserInterface.php
@@ -1,14 +1,12 @@
 <?php
+
 namespace App\Entity;
 
 use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 interface UserInterface extends SymfonyUserInterface, \Serializable
 {
 }
-

--- a/application/src/Event/Menu/Topbar/UserMenuEvent.php
+++ b/application/src/Event/Menu/Topbar/UserMenuEvent.php
@@ -10,29 +10,29 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class UserMenuEvent extends Event
 {
     public const EVENT = 'app.menu.topbar.user';
-    
+
     /**
      * @var FactoryInterface
      */
     private $factory;
-    
+
     /**
      * @var ItemInterface
      */
     private $item;
-    
+
     /**
      * @var RequestStack
      */
     private $request;
-    
+
     public function __construct(FactoryInterface $factory, ItemInterface $item, RequestStack $request)
     {
         $this->factory = $factory;
         $this->item = $item;
         $this->request = $request;
     }
-    
+
     /**
      * @return FactoryInterface
      */
@@ -40,7 +40,7 @@ class UserMenuEvent extends Event
     {
         return $this->factory;
     }
-    
+
     /**
      * @return ItemInterface
      */
@@ -48,7 +48,7 @@ class UserMenuEvent extends Event
     {
         return $this->item;
     }
-    
+
     /**
      * @return RequestStack
      */

--- a/application/src/Form/UserType.php
+++ b/application/src/Form/UserType.php
@@ -1,11 +1,11 @@
-<?php 
+<?php
+
 namespace App\Form;
 
 use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -16,18 +16,18 @@ class UserType extends AbstractType
     {
         $builder
             ->add('username', TextType::class)
-            ->add('plainPassword', RepeatedType::class, array(
+            ->add('plainPassword', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'first_options'  => array('label' => 'Password'),
-                'second_options' => array('label' => 'Repeat Password'),
-            ))
+                'first_options' => ['label' => 'Password'],
+                'second_options' => ['label' => 'Repeat Password'],
+            ])
         ;
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'data_class' => User::class,
-        ));
+        ]);
     }
 }

--- a/application/src/Menu/Menu.php
+++ b/application/src/Menu/Menu.php
@@ -1,4 +1,5 @@
 <?php
+
 // src/Menu/Menu.php
 
 namespace App\Menu;
@@ -11,36 +12,35 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class Menu
 {
-    
     /**
      * @var EventDispatcherInterface
      */
     private $dispatcher;
-    
+
     /**
      * @var FactoryInterface
      */
     private $factory;
-    
+
     public function __construct(FactoryInterface $factory, EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
         $this->factory = $factory;
     }
-    
+
     public function userTopbar(RequestStack $request): ItemInterface
     {
-        $menu = $this->factory->createItem('root', array(
-            'childrenAttributes'    => array(
-                'class'             => 'navbar-nav mr-auto',
-            ),
-        ));
-        
+        $menu = $this->factory->createItem('root', [
+            'childrenAttributes' => [
+                'class' => 'navbar-nav mr-auto',
+            ],
+        ]);
+
         $this->dispatcher->dispatch(
             UserMenuEvent::EVENT,
             new UserMenuEvent($this->factory, $menu, $request)
             );
-        
+
         return $menu;
-    }   
+    }
 }

--- a/application/src/Repository/UserRepository.php
+++ b/application/src/Repository/UserRepository.php
@@ -1,14 +1,12 @@
 <?php
+
 namespace App\Repository;
 
 use Doctrine\ORM\EntityRepository;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class UserRepository extends EntityRepository
 {
 }
-

--- a/application/src/Subscriber/UserMenuSubscriber.php
+++ b/application/src/Subscriber/UserMenuSubscriber.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace App\Subscriber;
+
 use App\Event\Menu\Topbar\UserMenuEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -7,15 +9,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class UserMenuSubscriber implements EventSubscriberInterface
 {
-
     /**
-     *
      * @var TokenStorageInterface
      */
     private $tokenStorage;
 
     /**
-     *
      * @var TranslatorInterface
      */
     private $translator;
@@ -42,7 +41,7 @@ class UserMenuSubscriber implements EventSubscriberInterface
         $menu->addChild(
             'imprint',
             [
-                'route'=>'imprint',
+                'route' => 'imprint',
                 'attributes' => [
                     'icon' => 'fas fa-address-card',
                 ],
@@ -95,7 +94,7 @@ class UserMenuSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            UserMenuEvent::EVENT => 'onUserMenuConfigure'
+            UserMenuEvent::EVENT => 'onUserMenuConfigure',
         ];
     }
 }

--- a/application/symfony.lock
+++ b/application/symfony.lock
@@ -1,4 +1,10 @@
 {
+    "composer/semver": {
+        "version": "1.4.2"
+    },
+    "composer/xdebug-handler": {
+        "version": "1.3.0"
+    },
     "doctrine/annotations": {
         "version": "1.0",
         "recipe": {
@@ -80,6 +86,15 @@
     "fig/link-util": {
         "version": "1.0.0"
     },
+    "friendsofphp/php-cs-fixer": {
+        "version": "2.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "2.2",
+            "ref": "81dee417d2cc60cd1c9d6208dff2ec22a1103e93"
+        }
+    },
     "jdorn/sql-formatter": {
         "version": "v1.2.17"
     },
@@ -106,6 +121,9 @@
     },
     "phar-io/version": {
         "version": "2.0.1"
+    },
+    "php-cs-fixer/diff": {
+        "version": "v1.3.0"
     },
     "phpdocumentor/reflection-common": {
         "version": "1.0.1"

--- a/application/tests/unit/Controller/DefaultControllerTest.php
+++ b/application/tests/unit/Controller/DefaultControllerTest.php
@@ -1,15 +1,13 @@
 <?php
-namespace App\Tests\Unit\Controller;
 
+namespace App\Tests\Unit\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use App\Controller\DefaultControllerInterface;
 use App\Controller\DefaultController;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class DefaultControllerTest extends WebTestCase
 {
@@ -17,21 +15,23 @@ class DefaultControllerTest extends WebTestCase
      * @var DefaultControllerInterface
      */
     protected $defaultController;
-    
-    public function setUp():void{
-        $this->defaultController = new DefaultController();    
+
+    public function setUp(): void
+    {
+        $this->defaultController = new DefaultController();
     }
-    
-    public function testHomepage():void{
+
+    public function testHomepage(): void
+    {
         $client = static::createClient();
         $client->request('GET', '/');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
-    
-    public function testImprint():void{
+
+    public function testImprint(): void
+    {
         $client = static::createClient();
         $client->request('GET', '/imprint');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 }
-

--- a/application/tests/unit/Controller/UserControllerTest.php
+++ b/application/tests/unit/Controller/UserControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Tests\Unit\Controller;
 
 use App\Controller\UserController;
@@ -6,41 +7,38 @@ use App\Controller\UserControllerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class UserControllerTest extends WebTestCase
 {
     /**
-     * 
      * @var UserControllerInterface
      */
     protected $userController;
-    
-    public function setUp():void{
+
+    public function setUp(): void
+    {
         $this->userController = new UserController();
     }
-    
+
     public function testLogout(): void
     {
         $client = static::createClient();
         $client->request('GET', '/user/logout');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
-    
+
     public function testLogin(): void
     {
         $client = static::createClient();
         $client->request('GET', '/login');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
-    
-    public function testRegister():void
+
+    public function testRegister(): void
     {
         $client = static::createClient();
         $client->request('GET', '/user/register');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }
 }
-

--- a/application/tests/unit/Entity/UserTest.php
+++ b/application/tests/unit/Entity/UserTest.php
@@ -1,38 +1,38 @@
 <?php
+
 namespace tests\unit\Entity;
 
 use PHPUnit\Framework\TestCase;
 use App\Entity\User;
 
 /**
- *
  * @author kevinfrantz
- *        
  */
 class UserTest extends TestCase
 {
     const PASSWORD = '12345678';
-    
+
     const USERNAME = 'tester';
-    
+
     /**
-     * 
      * @var User
      */
     protected $user;
-    
-    public function setUp():void{
+
+    public function setUp(): void
+    {
         $this->user = new User();
         $this->user->setPassword(self::PASSWORD);
         $this->user->setUsername(' '.self::USERNAME.' ');
     }
-    
-    public function testUsername():void{
-        $this->assertEquals(self::USERNAME,$this->user->getUsername());
+
+    public function testUsername(): void
+    {
+        $this->assertEquals(self::USERNAME, $this->user->getUsername());
     }
-    
-    public function testPassword():void{
-        $this->assertEquals(self::PASSWORD,$this->user->getPassword());
+
+    public function testPassword(): void
+    {
+        $this->assertEquals(self::PASSWORD, $this->user->getPassword());
     }
 }
-


### PR DESCRIPTION
There's less cognitive overhead when reading code that follows a consistent formatting scheme. This PR introduces PHP-CS-Fixer for enforcing formatting rules consistently.